### PR TITLE
README: fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# [internetgirlfriend.club](internetgirlfriend.club)
+# [internetgirlfriend.club](http://internetgirlfriend.club)
 
 In the wise words of Miley Cyrus, "They say you gotta think what you want into existence, but I've never been too good at making decisions."


### PR DESCRIPTION
The link on top of the README file was broken, because Github assumed it was a relative link. Prepending a URL scheme (`http://` in this case) should fix that!

Cheers